### PR TITLE
국내 코로나19 확진자 성별 감염 비율 Pie Chart 구현 (Pie chart 적용)

### DIFF
--- a/pybo/static/css/covid19_inkorea.css
+++ b/pybo/static/css/covid19_inkorea.css
@@ -1,0 +1,44 @@
+th, td{
+    text-align: center;
+}
+body, html {
+    margin: 0;
+    padding: 0;
+    height: 100%;
+}
+
+.container {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+}
+
+.map-container {
+    flex: 1;
+    width: 100%;
+    height: 600px;
+    margin-bottom: 20px;
+}
+
+.height_scroll {
+    height: 520px;
+    overflow-x: hidden;
+    overflow-y: auto;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+th, td {
+    text-align: center;
+    border: 1px solid #ddd;
+    padding: 8px;
+}
+
+th {
+    background-color: #f2f2f2;
+    position: sticky;
+    top: 0;
+}

--- a/pybo/static/css/covid19_inkorea.css
+++ b/pybo/static/css/covid19_inkorea.css
@@ -11,6 +11,7 @@ body, html {
     display: flex;
     flex-direction: column;
     height: 100%;
+    margin-bottom: 30px;
 }
 
 .map-container {

--- a/pybo/static/css/gender_pie_chart.css
+++ b/pybo/static/css/gender_pie_chart.css
@@ -1,0 +1,13 @@
+/* 차트 사이즈 크기 제한 두기 */
+.chart-container {
+    position: relative;
+    max-width: 600px;
+    max-height: 600px; 
+    margin: 100px auto; 
+    text-align: center;
+}
+
+canvas {
+    width: 100%; 
+    height: 100%; 
+}

--- a/pybo/static/css/gender_pie_chart.css
+++ b/pybo/static/css/gender_pie_chart.css
@@ -3,11 +3,17 @@
     position: relative;
     max-width: 600px;
     max-height: 600px; 
-    margin: 100px auto; 
+    margin: 40px auto 150px auto; 
     text-align: center;
 }
 
 canvas {
     width: 100%; 
     height: 100%; 
+}
+h6{
+    color: darkgray;
+}
+h5{
+    color: blue;
 }

--- a/pybo/static/css/gender_pie_chart.css
+++ b/pybo/static/css/gender_pie_chart.css
@@ -3,17 +3,31 @@
     position: relative;
     max-width: 600px;
     max-height: 600px; 
-    margin: 40px auto 150px auto; 
+    margin: 40px auto 180px auto; 
     text-align: center;
 }
 
 canvas {
     width: 100%; 
-    height: 100%; 
+    height: 100%;
 }
 h6{
     color: darkgray;
 }
-h5{
+#total_sum{
     color: blue;
+}
+.datainform1{
+    margin-bottom: 15px;
+}
+
+.datainform2{
+    margin-top: 20px;;
+}
+#subinform{
+    width: 40%;
+    text-align: center;
+    margin: 20px auto;
+    padding: 10px;
+
 }

--- a/pybo/static/js/gender_pie_chart.js
+++ b/pybo/static/js/gender_pie_chart.js
@@ -8,6 +8,7 @@ document.addEventListener("DOMContentLoaded", function() {
             data: Object.values(pieChartData),
             backgroundColor: ['#37a3eb', '#FF6384'],
             borderWidth: 1,
+            hoverOffset: 35,
             hoverBackgroundColor:['#008ae6','#ff335f'],
         }]
     };
@@ -15,9 +16,10 @@ document.addEventListener("DOMContentLoaded", function() {
     var options = {
         responsive: true,
         maintainAspectRatio: false,
-        hover: {
-            mode: 'nearest',
-            intersect: true
+        layout:{
+            padding:{
+                bottom: 15
+            },
         },
         plugins: {
             legend: {

--- a/pybo/static/js/gender_pie_chart.js
+++ b/pybo/static/js/gender_pie_chart.js
@@ -1,14 +1,13 @@
 document.addEventListener("DOMContentLoaded", function() {
     const ctx = document.getElementById('genderChart').getContext('2d');
 
-    // Use the globally defined pieChartData variable
     var data = {
         labels: Object.keys(pieChartData),
         datasets: [{
             data: Object.values(pieChartData),
             backgroundColor: ['#37a3eb', '#FF6384'],
             borderWidth: 1,
-            hoverOffset: 35,
+            hoverOffset: 50,
             hoverBackgroundColor:['#008ae6','#ff335f'],
         }]
     };
@@ -25,15 +24,44 @@ document.addEventListener("DOMContentLoaded", function() {
             legend: {
                 position: 'top',
             },
-            tooltip: {
-                callbacks: {
+            datalabels:{
+                align: 'center',
+                color: '#ffffff',   // 흰색글자
+                font: {
+                    size: 35,  //글자 크기 16px
+                    weight: 'bold'   // 글자 굵기를 볼드체로 설정
+                },
+                formatter: (value, context) =>{
+                    //console.log(value)
+                    //console.log(context)
+                    //console.log(context.chart.data.datasets[0].data);
+                    const datapoints = context.chart.data.datasets[0].data;
+                    const genderLabels = context.chart.data.labels;
+                    function totalSum(total, datapoint){
+                        return total + datapoint;
+                    }
+                    const totalValue = datapoints.reduce(totalSum, 0);
+                    const percentageValue = (value / totalValue * 100).toFixed(1);
+                    
+                    // 현재 데이터 포인트의 인덱스 가져오기
+                    const dataIndex = context.dataIndex;
+                    // genderLabels 배열에서 현재 인덱스에 해당하는 라벨 가져오기
+                    const genderLabel = genderLabels[dataIndex];
+
+                    return `${genderLabel}: (${percentageValue}%)`;
+                }
+            },
+            tooltip: {                      
+                enabled: false,   // formatter 데이터 살리기 위해서 툹팁 비활성화
+                callbacks: {                             
                     label: function(context) {
                         var label = context.label || '';
-                        var value = context.raw || 0;
-                        var total = context.dataset.data.reduce((sum, current) => sum + current, 0);
-                        console.log(total);
-                        var percentage = (value / total * 100).toFixed(1);
-                        return `${label}: ${value} (${percentage}%)`;
+                        var value = context.raw || 0;         // 주석 처리한 3줄은 퍼센트 데이터까지 모두 표현하고 싶은 경우
+                        // var total = context.dataset.data.reduce((sum, current) => sum + current, 0);  
+                        // var percentage = (value / total * 100).toFixed(1);          
+                        //return `${label}: ${value} (${percentage}%)`;
+                        var formattedValue = value.toLocaleString();
+                        return `${label}: ${formattedValue}명`;
                     }
                 }
             },
@@ -43,6 +71,7 @@ document.addEventListener("DOMContentLoaded", function() {
     var genderChart = new Chart(ctx, {
         type: 'pie',
         data: data,
-        options: options
+        options: options,
+        plugins: [ChartDataLabels]
     });
 });

--- a/pybo/static/js/gender_pie_chart.js
+++ b/pybo/static/js/gender_pie_chart.js
@@ -1,0 +1,46 @@
+document.addEventListener("DOMContentLoaded", function() {
+    const ctx = document.getElementById('genderChart').getContext('2d');
+
+    // Use the globally defined pieChartData variable
+    var data = {
+        labels: Object.keys(pieChartData),
+        datasets: [{
+            data: Object.values(pieChartData),
+            backgroundColor: ['#37a3eb', '#FF6384'],
+            borderWidth: 1,
+            hoverBackgroundColor:['#008ae6','#ff335f'],
+        }]
+    };
+
+    var options = {
+        responsive: true,
+        maintainAspectRatio: false,
+        hover: {
+            mode: 'nearest',
+            intersect: true
+        },
+        plugins: {
+            legend: {
+                position: 'top',
+            },
+            tooltip: {
+                callbacks: {
+                    label: function(context) {
+                        var label = context.label || '';
+                        var value = context.raw || 0;
+                        var total = context.dataset.data.reduce((sum, current) => sum + current, 0);
+                        console.log(total);
+                        var percentage = (value / total * 100).toFixed(1);
+                        return `${label}: ${value} (${percentage}%)`;
+                    }
+                }
+            },
+        },
+    };
+
+    var genderChart = new Chart(ctx, {
+        type: 'pie',
+        data: data,
+        options: options
+    });
+});

--- a/pybo/templates/base.html
+++ b/pybo/templates/base.html
@@ -65,7 +65,7 @@
           <li><a href="{{url_for('citygungu.covid19_inkorea')}}">국내</a></li>
           <li><a href="{{ url_for('world.worldmap') }}">전세계</a></li>
           <li><a href="#">일자별</a></li>
-          <li><a href="#">성별</a></li>
+          <li><a href="{{ url_for('chart.gender_chart')}}">성별</a></li>
           <li><a href="{{ url_for('chart.age_chart') }}">나이대별</a></li>
 
           <!-- <li class="dropdown"><a href="#"><span>Drop Down</span> <i class="bi bi-chevron-down dropdown-indicator"></i></a>

--- a/pybo/templates/inkorea/covid19_inkorea.html
+++ b/pybo/templates/inkorea/covid19_inkorea.html
@@ -2,53 +2,7 @@
 
 {% block css %}
   <!-- css 넣을거 있으면 넣으면됨 -->
-  <style>
-    th, td{
-        text-align: center;
-    }
-    body, html {
-        margin: 0;
-        padding: 0;
-        height: 100%;
-    }
-
-    .container {
-        display: flex;
-        flex-direction: column;
-        height: 100%;
-    }
-
-    .map-container {
-        flex: 1;
-        width: 100%;
-        height: 600px;
-        margin-bottom: 20px;
-    }
-
-    .height_scroll {
-        height: 520px;
-        overflow-x: hidden;
-        overflow-y: auto;
-    }
-
-    table {
-        width: 100%;
-        border-collapse: collapse;
-    }
-
-    th, td {
-        text-align: center;
-        border: 1px solid #ddd;
-        padding: 8px;
-    }
-
-    th {
-        background-color: #f2f2f2;
-        position: sticky;
-        top: 0;
-    }
-
-  </style>
+   <link rel="stylesheet" href="{{url_for('static', filename='/css/covid19_inkorea.css')}}">
 {% endblock %}
 
 {% block content %}
@@ -62,18 +16,7 @@
           <div class="row d-flex justify-content-center">
             <div class="col-lg-6 text-center">
               <h2>국내 코로나(Covid-19) 확진자 및 사망자 현황</h2>
-              <pre>
-                ′23.8.31일 0시 기준<br> 
-                질병관리청 질병보건통합관리시스템에 신고된 코로나19 확진환자 및 사망자<br> 
-                (사망자 집계는 환자발생 신고지역 기준)<br> 
-                (발생률) '20.1월 이후 시군구별 누적 확진자수 / 시군구별 별 인구수<br> 
-                (‘22.12월 행정안전부 주민등록인구현황 기준)<br> 
-                (사망률) '20.1월 이후 시군구별 누적 사망자수 / 시군구별 인구수<br>
-                (‘22.12월 행정안전부 주민등록인구현황 기준)<br>
-                23.7.1. 군위군 행정구역이 경상북도에서 대구광역시로 편입됨에 따라,<br>
-                해당일자부터 확진자 및 사망자 집계의 신고시도가 변경됨.<br>
-                단, 발생률의 경우 기존 경상북도 기준으로 산출
-              </pre>
+               <p>국내 누적 확진및 사망자에 대한 분포도 시각화 자료 입니다.</p>
             </div>
           </div>
         </div>
@@ -81,6 +24,18 @@
     </div><!-- End Breadcrumbs -->
 
     <div class="container">
+        <div class="alert alert-danger role=alert">
+            ′23.8.31일 0시 기준<br> 
+            질병관리청 질병보건통합관리시스템에 신고된 코로나19 확진환자 및 사망자<br> 
+            (사망자 집계는 환자발생 신고지역 기준)<br> 
+            (발생률) '20.1월 이후 시군구별 누적 확진자수 / 시군구별 별 인구수<br> 
+            (‘22.12월 행정안전부 주민등록인구현황 기준)<br> 
+            (사망률) '20.1월 이후 시군구별 누적 사망자수 / 시군구별 인구수<br>
+            (‘22.12월 행정안전부 주민등록인구현황 기준)<br>
+            23.7.1. 군위군 행정구역이 경상북도에서 대구광역시로 편입됨에 따라,<br>
+            해당일자부터 확진자 및 사망자 집계의 신고시도가 변경됨.<br>
+            단, 발생률의 경우 기존 경상북도 기준으로 산출
+        </div>
         <div class="map-container"> 
                 {{map|safe}}
         </div>
@@ -133,7 +88,6 @@
         $("#select_city").change(function(){
             let selected_city = $(this).val();
             location.href= '/citygungu/covid19_inkorea/'+selected_city;
-
     });
 });
 </script>

--- a/pybo/templates/inkorea/covid19_inkorea.html
+++ b/pybo/templates/inkorea/covid19_inkorea.html
@@ -24,7 +24,7 @@
     </div><!-- End Breadcrumbs -->
 
     <div class="container">
-        <div class="alert alert-danger role=alert">
+        <div class="alert alert-danger role=alert mt-3">
             ′23.8.31일 0시 기준<br> 
             질병관리청 질병보건통합관리시스템에 신고된 코로나19 확진환자 및 사망자<br> 
             (사망자 집계는 환자발생 신고지역 기준)<br> 

--- a/pybo/templates/inkorea/gender_pie_chart.html
+++ b/pybo/templates/inkorea/gender_pie_chart.html
@@ -1,0 +1,44 @@
+{% extends 'base.html' %}
+
+{% block css %}
+<link rel="stylesheet" href="{{url_for('static', filename='/css/gender_pie_chart.css')}}">
+{% endblock %}
+
+{% block content %}
+
+<main id="main">
+
+  <!-- ======= Breadcrumbs ======= -->
+  <div class="breadcrumbs">
+    <div class="page-header d-flex align-items-center" style="background-image: url('{{url_for('static', filename='assets/img/page-header.jpg')}}');">
+      <div class="container position-relative">
+        <div class="row d-flex justify-content-center">
+          <div class="col-lg-7 text-center">
+            <h2>코로나바이러스감염증-19 전체 확진환자 성별 구분 현황</h2>
+            <p>코로나 성별 감염 비율을 나타낸 원형 데이터표</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div><!-- End Breadcrumbs -->
+
+  <!-- 페이지에 출력할 내용 작업 -->
+  <div class="alert alert-danger role=alert">
+  - ′23.8.31일 0시 기준, 질병관리청 질병보건통합관리시스템에 신고된 코로나19 확진환자
+  </div>
+  <div class="chart-container">
+    <h2>국내 남자/여자(성별) 감염 차트</h2>
+    <canvas id="genderChart"></canvas>
+  </div>
+
+</main> <!-- End Main -->
+
+{% endblock %}
+
+{% block script %}
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.4.0/Chart.min.js"></script>
+  <script> 
+    let pieChartData = {{pie_chart | tojson}};
+  </script>
+  <script src="{{ url_for('static', filename='js/gender_pie_chart.js') }}"></script>
+{% endblock %}

--- a/pybo/templates/inkorea/gender_pie_chart.html
+++ b/pybo/templates/inkorea/gender_pie_chart.html
@@ -13,9 +13,9 @@
     <div class="page-header d-flex align-items-center" style="background-image: url('{{url_for('static', filename='assets/img/page-header.jpg')}}');">
       <div class="container position-relative">
         <div class="row d-flex justify-content-center">
-          <div class="col-lg-7 text-center">
-            <h2>코로나바이러스감염증-19 전체 확진환자 성별 구분 현황</h2>
-            <p>코로나 성별 감염 비율을 나타낸 원형 데이터표</p>
+          <div class="col-lg-8 text-center">
+            <h2>국내 코로나(Covid-19) 확진자 남/여(성) 비율 현황표</h2>
+            <p>코로나 성별 감염 비율을 원형 데이터표 나타냈습니다. </p>
           </div>
         </div>
       </div>
@@ -28,6 +28,13 @@
   </div>
   <div class="chart-container">
     <h2>국내 남자/여자(성별) 감염 차트</h2>
+    {% for key, val in sumTotal_gender.items() %}
+        {% if key == '총 확진자' %}
+            {% set result_data = val %}
+          <h5>총 확진자: {{ result_data['전체'] }}명</h5>
+          <h6>질병관리청 ′23.8.31일 0시 집계 기준</h6>
+        {% endif%}
+    {% endfor %}
     <canvas id="genderChart"></canvas>
   </div>
 
@@ -36,7 +43,7 @@
 {% endblock %}
 
 {% block script %}
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.4.0/Chart.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js"></script>
   <script> 
     let pieChartData = {{pie_chart | tojson}};
   </script>

--- a/pybo/templates/inkorea/gender_pie_chart.html
+++ b/pybo/templates/inkorea/gender_pie_chart.html
@@ -23,19 +23,38 @@
   </div><!-- End Breadcrumbs -->
 
   <!-- 페이지에 출력할 내용 작업 -->
-  <div class="alert alert-danger role=alert">
+  <div class="alert alert-danger role=alert" id="subinform">
   - ′23.8.31일 0시 기준, 질병관리청 질병보건통합관리시스템에 신고된 코로나19 확진환자
   </div>
+
   <div class="chart-container">
     <h2>국내 남자/여자(성별) 감염 차트</h2>
-    {% for key, val in sumTotal_gender.items() %}
-        {% if key == '총 확진자' %}
-            {% set result_data = val %}
-          <h5>총 확진자: {{ result_data['전체'] }}명</h5>
-          <h6>질병관리청 ′23.8.31일 0시 집계 기준</h6>
-        {% endif%}
-    {% endfor %}
-    <canvas id="genderChart"></canvas>
+    
+    <div class="datainform1">
+      {% for key, val in sumTotal_gender.items() %}
+          {% if key == '총 확진자' %}
+              {% set result_data = val %}
+            <h5 id="total_sum">총 확진자: {{ result_data['전체'] }}명</h5>
+            <h6>질병관리청 ′23.8.31일 0시 집계 기준</h6>
+          {% endif%}
+      {% endfor %}
+   </div>
+    
+   <canvas id="genderChart" width=400 height=350></canvas>
+    
+    <div class="datainform2">
+      {% for key, val in sumTotal_gender.items() %}
+          {% if key == '남자' %}
+              {% set result_man = val %}
+              <h5> 확진자(남자): 총 {{ result_man['전체'] }}명 |
+          {% endif%}
+          
+          {% if key == '여자' %}
+              {% set result_woman = val %}
+              확진자(여자): 총 {{ result_woman['전체'] }}명</h5>  
+          {% endif %}
+      {% endfor %}
+    </div>
   </div>
 
 </main> <!-- End Main -->
@@ -43,7 +62,12 @@
 {% endblock %}
 
 {% block script %}
-  <script src="https://cdn.jsdelivr.net/npm/chart.js/dist/chart.umd.min.js"></script>
+
+  <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+ <script src="https://cdnjs.cloudflare.com/ajax/libs/chartjs-plugin-datalabels/2.0.0/chartjs-plugin-datalabels.min.js" 
+  integrity="sha512-R/QOHLpV1Ggq22vfDAWYOaMd5RopHrJNMxi8/lJu8Oihwi4Ho4BRFeiMiCefn9rasajKjnx9/fTQ/xkWnkDACg==" 
+  crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
   <script> 
     let pieChartData = {{pie_chart | tojson}};
   </script>

--- a/pybo/views/chart_views.py
+++ b/pybo/views/chart_views.py
@@ -24,7 +24,12 @@ def gender_chart():
     total_pivot_df = pd.pivot_table(gender_df, values=["남자", "여자"], index="연도", aggfunc="sum", margins=True, margins_name="전체")
     pie_chart= total_pivot_df.loc["전체"].to_dict()
 
-    return render_template("inkorea/gender_pie_chart.html", pie_chart=pie_chart)
+    total_pivot_df.drop(total_pivot_df.index[:4], inplace=True)
+    total_pivot_df['총 확진자'] = total_pivot_df.sum(axis=1)
+    total_pivot_df['총 확진자']['전체'] = "{:,}".format(total_pivot_df['총 확진자']['전체'])
+    sumTotal_gender = total_pivot_df.to_dict()
+
+    return render_template("inkorea/gender_pie_chart.html", pie_chart=pie_chart, sumTotal_gender=sumTotal_gender)
 
 # 엑셀 파일 읽어오기
 cov_data = pd.read_excel(os.path.join("pybo", "static", "chart_xlsx", "cov_data.xlsx"))

--- a/pybo/views/chart_views.py
+++ b/pybo/views/chart_views.py
@@ -1,15 +1,10 @@
 from flask import Flask, Blueprint, render_template, jsonify
 import pandas as pd
-import matplotlib.pyplot as plt
-from io import BytesIO
-import base64
 import os
 
 app = Flask(__name__)
 bp = Blueprint("chart", __name__, url_prefix="/chart")
 
-plt.rcParams['font.family']="Malgun Gothic"  # 한글 깨짐 방지
-plt.rcParams['axes.unicode_minus']=False     # - 표기 깨짐 방지
 gender_df = pd.read_excel('pybo\static\others\코로나19 확진자 발생현황.xlsx', sheet_name=3, skiprows=3, header=1)
 gender_df.drop([0], axis="index", inplace=True)
 gender_df.replace("-", 0, inplace=True)
@@ -27,6 +22,8 @@ def gender_chart():
     total_pivot_df.drop(total_pivot_df.index[:4], inplace=True)
     total_pivot_df['총 확진자'] = total_pivot_df.sum(axis=1)
     total_pivot_df['총 확진자']['전체'] = "{:,}".format(total_pivot_df['총 확진자']['전체'])
+    total_pivot_df['남자']['전체'] = "{:,}".format(total_pivot_df['남자']['전체'])
+    total_pivot_df['여자']['전체'] = "{:,}".format(total_pivot_df['여자']['전체'])
     sumTotal_gender = total_pivot_df.to_dict()
 
     return render_template("inkorea/gender_pie_chart.html", pie_chart=pie_chart, sumTotal_gender=sumTotal_gender)

--- a/pybo/views/chart_views.py
+++ b/pybo/views/chart_views.py
@@ -1,9 +1,30 @@
 from flask import Flask, Blueprint, render_template, jsonify
 import pandas as pd
+import matplotlib.pyplot as plt
+from io import BytesIO
+import base64
 import os
 
 app = Flask(__name__)
 bp = Blueprint("chart", __name__, url_prefix="/chart")
+
+plt.rcParams['font.family']="Malgun Gothic"  # 한글 깨짐 방지
+plt.rcParams['axes.unicode_minus']=False     # - 표기 깨짐 방지
+gender_df = pd.read_excel('pybo\static\others\코로나19 확진자 발생현황.xlsx', sheet_name=3, skiprows=3, header=1)
+gender_df.drop([0], axis="index", inplace=True)
+gender_df.replace("-", 0, inplace=True)
+gender_df.rename(columns={"남성(명)":"남자","여성(명)": "여자"}, inplace=True)
+gender_df["연도"]= gender_df["일자"].dt.year
+gender_df["월"]= gender_df["일자"].dt.month
+
+
+@bp.route("/gender_each_chart")
+def gender_chart():
+    
+    total_pivot_df = pd.pivot_table(gender_df, values=["남자", "여자"], index="연도", aggfunc="sum", margins=True, margins_name="전체")
+    pie_chart= total_pivot_df.loc["전체"].to_dict()
+
+    return render_template("inkorea/gender_pie_chart.html", pie_chart=pie_chart)
 
 # 엑셀 파일 읽어오기
 cov_data = pd.read_excel(os.path.join("pybo", "static", "chart_xlsx", "cov_data.xlsx"))

--- a/pybo/views/citygungu_views.py
+++ b/pybo/views/citygungu_views.py
@@ -38,7 +38,7 @@ df1.replace("-", 0, inplace=True)
 df1 = pd.merge(df, dfn, on=["시도명","시군구"])
 filter = df1["시군구"] != "합계"
 df1 = df1[filter]
-print(df1[df1['시도명'] == '경기'])
+# print(df1[df1['시도명'] == '경기'])
 
     ## 각 시도명 기준으로 나누어 출력하는 함수 ##
 def citys(df, city_list):
@@ -48,7 +48,7 @@ def citys(df, city_list):
         city_df = df[df1["시도명"]== city]
         city_data_list.append(city_df)
     
-    return [df[df['시도명'].isin(city_list)]]
+    return city_data_list
 
     ##  누적확진자, 누적 사망자 값 가져오는 함수 ##
 def make_import_data(df1, city, gungu):
@@ -137,7 +137,7 @@ def covid19_inkorea_city(selected_city):
           exact_duplicate_pairs.append((value, keys))
 
     dup_city = []
-    print("정확히 일치하는 중복된 값의 value와 keys:")
+    # print("정확히 일치하는 중복된 값의 value와 keys:")
     for value, keys in exact_duplicate_pairs:
         print(f"{value} : {keys}")
         dup_city.append(value)

--- a/pybo/views/citygungu_views.py
+++ b/pybo/views/citygungu_views.py
@@ -135,11 +135,11 @@ def covid19_inkorea_city(selected_city):
     for value, keys in duplicate_values.items():
       if len(keys) > 1 and len(set(arr[key] for key in keys)) == 1:
           exact_duplicate_pairs.append((value, keys))
-
+          
     dup_city = []
-    # print("정확히 일치하는 중복된 값의 value와 keys:")
+    #print("정확히 일치하는 중복된 값의 value와 keys:")
     for value, keys in exact_duplicate_pairs:
-        print(f"{value} : {keys}")
+        #print(f"{value} : {keys}")
         dup_city.append(value)
 
     # 작업해보니 code는 추출할 필요가 없었음
@@ -159,7 +159,7 @@ def covid19_inkorea_city(selected_city):
             feature['properties']['name'] = feature['id'][:feature['id'].find(' ')] + ' ' + feature['properties']['name']
           else:
             feature['properties']['name'] = feature['id'] + ' ' + feature['properties']['name']  
-          print(feature['properties']['name'])
+          #print(feature['properties']['name'])
 
     for r in result:
         if r['시군구'] == '세종':
@@ -235,7 +235,7 @@ def covid19_inkorea():
     for feature in geoJson_data['features']:    # geojson과 위경도 name값 매칭을 위한 for문
         if 'name' in feature['properties']:
             for entry in result:
-                if entry['시군구'][:3] in feature['properties']['name'][-3:]:
+                if entry['시군구'] in feature['properties']['name']:
                     feature['properties']['name'] = entry['시군구']
 
     data_dict = {entry['시군구'] : entry['확진자'] for entry in result}


### PR DESCRIPTION
## 데이터 구현에 사용한 라이브러리
- pandas
- chart.js  (Pie chart)

## 구현한 기능
 - Pie chart
 - hoverOffest 적용
 - hoverBackgroundColor 적용 
 - datalabels 적용 (formatter)
 - 그 외 직관적으로 확인 가능한 데이터 수치 구현 ( html )

## 데이터 가공 기준
Pie chart는 일일 데이터 보다 전체 데이터를 보기에 적합한 차트 입니다.
그래서 성별 기준으로 코로나 최초 발별 시기로 부터 마지막으로 수집된 데이터 날짜 2023년 8월 31일 기준으로 각각의 전체 합계데이터 와 비율 정보를 생성 하였습니다.
 
## 사용한 원본 데이터 출처
- 공공데이터포털에서 코로나19 국내 전수감시 데이터 일부 사용